### PR TITLE
replaces log snippet single-quotes with double-quotes

### DIFF
--- a/snippets/log.json
+++ b/snippets/log.json
@@ -2,56 +2,56 @@
     "Log-alert.sublime-snippet": {
         "prefix": "Log::alert",
         "body": [
-            "Log::alert('${1:message}');$2"
+            "Log::alert(\"${1:message}\");$2"
         ],
         "description": "Log an alert message to the logs."
     },
     "Log-critical.sublime-snippet": {
         "prefix": "Log::critical",
         "body": [
-            "Log::critical('${1:message}');$2"
+            "Log::critical(\"${1:message}\");$2"
         ],
         "description": "Log a critical message to the logs."
     },
     "Log-debug.sublime-snippet": {
         "prefix": "Log::debug",
         "body": [
-            "Log::debug('${1:message}');$2"
+            "Log::debug(\"${1:message}\");$2"
         ],
         "description": "Log a debug message to the logs."
     },
     "Log-emergency.sublime-snippet": {
         "prefix": "Log::emergency",
         "body": [
-            "Log::emergency('${1:message}');$2"
+            "Log::emergency(\"${1:message}\");$2"
         ],
         "description": "Log an emergency message to the logs."
     },
     "Log-error.sublime-snippet": {
         "prefix": "Log::error",
         "body": [
-            "Log::error('${1:message}');$2"
+            "Log::error(\"${1:message}\");$2"
         ],
         "description": "Log an error message to the logs."
     },
     "Log-info.sublime-snippet": {
         "prefix": "Log::info",
         "body": [
-            "Log::info('${1:message}');$2"
+            "Log::info(\"${1:message}\");$2"
         ],
         "description": "Log an informational message to the logs."
     },
     "Log-log.sublime-snippet": {
         "prefix": "Log::log",
         "body": [
-            "Log::log('${1:level}', '${2:message}');$3"
+            "Log::log(\"${1:level}\", \"${2:message}\");$3"
         ],
         "description": "Log a message to the logs."
     },
     "Log-notice.sublime-snippet": {
         "prefix": "Log::notice",
         "body": [
-            "Log::notice(${1:message});$2"
+            "Log::notice(\"${1:message}\");$2"
         ],
         "description": "Log a notice to the logs."
     },
@@ -72,7 +72,7 @@
     "Log-warning.sublime-snippet": {
         "prefix": "Log::warning",
         "body": [
-            "Log::warning('${1:message}');$2"
+            "Log::warning(\"${1:message}\");$2"
         ],
         "description": "Log a warning message to the logs."
     }


### PR DESCRIPTION
This PR replaces single-quotation-marks in the log message snippets with double quotation marks,
making it easier to use string interpolation in log messages as stated in #28 

I've taken care of the necessary escaping for the quotation marks.